### PR TITLE
Add httpd options directives and ssl vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,10 @@ This example is taken from `molecule/resources/converge.yml` and is tested on ea
       httpd_vhosts:
         - name: docroot
           servername: www1.example.com
-          options: +Indexes +FollowSymLinks -MultiViews
+          options:
+            - +Indexes
+            - +FollowSymLinks
+            - -MultiViews
           documentroot: /var/www/html/www1.example.com
         - name: backend_http
           servername: www2.example.com

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This example is taken from `molecule/resources/converge.yml` and is tested on ea
       httpd_vhosts:
         - name: docroot
           servername: www1.example.com
+          options: +Indexes +FollowSymLinks -MultiViews
           documentroot: /var/www/html/www1.example.com
         - name: backend_http
           servername: www2.example.com
@@ -84,7 +85,7 @@ For verification `molecule/resources/verify.yml` run after the role has been app
       default: /var/www/html
       Alpine: /var/www/localhost
       Suse: /srv/www/htdocs
-    
+
     httpd_data_directory: "{{ _httpd_data_directory[ansible_os_family] | default(_httpd_data_directory['default']) }}"
 
   tasks:

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ This example is taken from `molecule/resources/converge.yml` and is tested on ea
         - name: docroot
           servername: www1.example.com
           options:
-            - +Indexes
-            - +FollowSymLinks
-            - -MultiViews
+            - "+Indexes"
+            - "+FollowSymLinks"
+            - "-MultiViews"
           documentroot: /var/www/html/www1.example.com
         - name: backend_http
           servername: www2.example.com

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,3 +15,9 @@ httpd_ssl_port: 443
 
 # Set ProxyPreserveHost
 httpd_proxy_preserve_host: On
+
+# SSL Certificate:
+httpd_openssl_crt: localhost.crt
+
+# SSL Key
+httpd_openssl_key: localhost.key

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,7 +17,7 @@ httpd_ssl_port: 443
 httpd_proxy_preserve_host: On
 
 # SSL Certificate:
-httpd_openssl_crt: localhost.crt
+httpd_openssl_crt: "{{ httpd_openssl_crt_directory }}/apache-httpd.crt"
 
 # SSL Key
-httpd_openssl_key: localhost.key
+httpd_openssl_key: "{{ httpd_openssl_key_directory }}/apache-httpd.key"

--- a/templates/ssl.conf.j2
+++ b/templates/ssl.conf.j2
@@ -6,6 +6,6 @@ Listen {{ httpd_ssl_port }}
 <VirtualHost *:{{ httpd_ssl_port }}>
     ServerName {{ httpd_ssl_servername }}
     SSLEngine on
-    SSLCertificateFile "{{ httpd_openssl_crt_directory }}/apache-httpd.crt"
-    SSLCertificateKeyFile "{{ httpd_openssl_key_directory }}/apache-httpd.key"
+    SSLCertificateFile "{{ httpd_openssl_crt_directory }}/{{ httpd_openssl_crt }}"
+    SSLCertificateKeyFile "{{ httpd_openssl_key_directory }}/{{ httpd_openssl_key }}"
 </VirtualHost>

--- a/templates/ssl.conf.j2
+++ b/templates/ssl.conf.j2
@@ -6,6 +6,6 @@ Listen {{ httpd_ssl_port }}
 <VirtualHost *:{{ httpd_ssl_port }}>
     ServerName {{ httpd_ssl_servername }}
     SSLEngine on
-    SSLCertificateFile "{{ httpd_openssl_crt_directory }}/{{ httpd_openssl_crt }}"
-    SSLCertificateKeyFile "{{ httpd_openssl_key_directory }}/{{ httpd_openssl_key }}"
+    SSLCertificateFile "{{ httpd_openssl_crt }}"
+    SSLCertificateKeyFile "{{ httpd_openssl_key }}"
 </VirtualHost>

--- a/templates/vhost.conf.j2
+++ b/templates/vhost.conf.j2
@@ -13,7 +13,7 @@
 <VirtualHost *:{{ httpd_port }}>
    ServerName {{ item.servername }}
 {% if item.options is defined %}
-   Options {{ item.options }}
+   Options {{ item.options|join(' ') }}
 {% endif %}
 {% if item.documentroot is defined %}
    DocumentRoot "{{ item.documentroot }}"

--- a/templates/vhost.conf.j2
+++ b/templates/vhost.conf.j2
@@ -12,6 +12,9 @@
 
 <VirtualHost *:{{ httpd_port }}>
    ServerName {{ item.servername }}
+   {% if item.options is defined %}
+      Options "{{ item.options }}"
+   {% endif %}
 {% if item.documentroot is defined %}
    DocumentRoot "{{ item.documentroot }}"
 {% endif %}

--- a/templates/vhost.conf.j2
+++ b/templates/vhost.conf.j2
@@ -12,9 +12,9 @@
 
 <VirtualHost *:{{ httpd_port }}>
    ServerName {{ item.servername }}
-   {% if item.options is defined %}
-      Options "{{ item.options }}"
-   {% endif %}
+{% if item.options is defined %}
+   Options {{ item.options }}
+{% endif %}
 {% if item.documentroot is defined %}
    DocumentRoot "{{ item.documentroot }}"
 {% endif %}


### PR DESCRIPTION
---
name: Options and SSL Updates
about: Added option directive and default ssl cert/keys variables:
---

**Describe the change**
- I needed to be able to allow file and directory browsing for an internal repo. To do this, I need to add the option directive as described [here](https://francescoficarola.com/apache-enable-files-directory-listing/). To do this, I simply updated the vhost template file to check to see if `options` key value exists and then write it out if it does.
.
- To get there, thought, I had to do some testing and during the run, it failed on `test httpd configuration validaty:
```
UNNING HANDLER [robertdebock.httpd : test httpd configuration validity] *******************************************************************************************************************************************
fatal: [rnode01]: FAILED! => {"changed": false, "cmd": ["httpd", "-t"], "delta": "0:00:00.255303", "end": "2020-06-20 21:03:12.751017", "msg": "non-zero return code", "rc": 1, "start": "2020-06-20 21:03:12.495714", "stderr": "[Sat Jun 20 21:03:12.720010 2020] [so:warn] [pid 19252] AH01574: module rewrite_module is already loaded, skipping\n[Sat Jun 20 21:03:12.720647 2020] [so:warn] [pid 19252] AH01574: module ssl_module is already loaded, skipping\nAH00526: Syntax error on line 11 of /etc/httpd/conf.d/ssl.conf:\nSSLCertificateFile: file '/etc/pki/tls/certs/apache-httpd.crt' does not exist or is empty", "stderr_lines": ["[Sat Jun 20 21:03:12.720010 2020] [so:warn] [pid 19252] AH01574: module rewrite_module is already loaded, skipping", "[Sat Jun 20 21:03:12.720647 2020] [so:warn] [pid 19252] AH01574: module ssl_module is already loaded, skipping", "AH00526: Syntax error on line 11 of /etc/httpd/conf.d/ssl.conf:", "SSLCertificateFile: file '/etc/pki/tls/certs/apache-httpd.crt' does not exist or is empty"], "stdout": "", "stdout_lines": []}
```
As it turns out, it  was looking for hard-coded cert and keys values [here](https://github.com/robertdebock/ansible-role-httpd/blob/46197f6cea968aee3c090804a44f0e50b43a93ed/templates/ssl.conf.j2#L9-L10), which is problematic as those file don't necessarily exist by default. So I created potentially variables with default values for the certificate and key files and substitute the hard-coded files with those variables.

**Testing**
In case a feature was added, how were tests performed?

No errors are found during the rule. Sites with and without options directive specified were created successfully and the httpd validation error did not crop up again:

```
TASK [robertdebock.bootstrap : wait for host] **********************************************************************************************************************************************************************
skipping: [node01]

TASK [robertdebock.bootstrap : test connection] ********************************************************************************************************************************************************************
ok: [node01]

TASK [robertdebock.bootstrap : set bootstrap ansible_user] *********************************************************************************************************************************************************
ok: [node01]

TASK [robertdebock.bootstrap : gather ansible facts] ***************************************************************************************************************************************************************
ok: [node01]

TASK [robertdebock.bootstrap : install bootstrap packages] *********************************************************************************************************************************************************
ok: [node01] => (item=python)
ok: [node01] => (item=sudo)

TASK [robertdebock.buildtools : install buildtools] ****************************************************************************************************************************************************************
ok: [node01]

TASK [robertdebock.python_pip : install python pip] ****************************************************************************************************************************************************************
ok: [node01]

TASK [robertdebock.python_pip : update pip] ************************************************************************************************************************************************************************
ok: [node01]

TASK [robertdebock.python_pip : set pip alternatives] **************************************************************************************************************************************************************
skipping: [node01]

TASK [robertdebock.python_pip : configure pip proxy] ***************************************************************************************************************************************************************
skipping: [node01]

TASK [robertdebock.python_pip : trust hosts] ***********************************************************************************************************************************************************************
skipping: [node01]

TASK [robertdebock.python_pip : install requested modules] *********************************************************************************************************************************************************

TASK [robertdebock.httpd : install apache httpd] *******************************************************************************************************************************************************************
ok: [node01]

TASK [robertdebock.httpd : modify selinux settings] ****************************************************************************************************************************************************************
ok: [node01] => (item=httpd_can_network_connect)

TASK [robertdebock.httpd : allow connections to custom port] *******************************************************************************************************************************************************
ok: [node01] => (item=80)
ok: [node01] => (item=443)

TASK [robertdebock.httpd : configure ssl] **************************************************************************************************************************************************************************
ok: [node01]

TASK [robertdebock.httpd : configure locations] ********************************************************************************************************************************************************************
skipping: [node01]

TASK [robertdebock.httpd : configure vhosts] ***********************************************************************************************************************************************************************
ok: [node01] => (item=blog.dev.example.com)
ok: [node01] => (item=ks.example.com)
ok: [node01] => (item=repo.example.com)

TASK [robertdebock.httpd : configure httpd] ************************************************************************************************************************************************************************
ok: [node01]

TASK [robertdebock.httpd : configure listening ports] **************************************************************************************************************************************************************
skipping: [node01]

TASK [robertdebock.httpd : configure redirect from http to https] **************************************************************************************************************************************************
ok: [node01]

TASK [robertdebock.httpd : create docroot] *************************************************************************************************************************************************************************
ok: [node01] => (item={'name': 'blog.dev.example.com', 'servername': 'blog.dev.example.com', 'documentroot': '/var/www/vhosts/blog.dev.example.com'})
ok: [node01] => (item={'name': 'ks.example.com', 'servername': 'ks.example.com', 'documentroot': '/var/www/vhosts/ks.example.com'})
ok: [node01] => (item={'name': 'repo.example.com', 'servername': 'repo.example.com', 'options': '+Indexes +FollowSymLinks -MultiViews', 'documentroot': '/var/www/vhosts/repo.example.com'})

TASK [robertdebock.httpd : start and enable httpd] *****************************************************************************************************************************************************************
ok: [node01]

```