### PR TITLE
Server alias support for vhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ This example is taken from `molecule/resources/converge.yml` and is tested on ea
           documentroot: /var/www/html/www1.example.com
         - name: backend_http
           servername: www2.example.com
+          serveralias:
+            - example.com
+            - special.com
           backend_url: "http://www.example.com/"
         - name: remote
           servername: www3.example.com

--- a/templates/vhost.conf.j2
+++ b/templates/vhost.conf.j2
@@ -13,9 +13,9 @@
 <VirtualHost *:{{ httpd_port }}>
    ServerName {{ item.servername }}
 
-   {% if item.serveralias is defined %}
+{% if item.serveralias is defined %}
    ServerAlias {{ item.serveralias | join(' ') }}
-   {% endif %}
+{% endif %}
 
 {% if item.options is defined %}
    Options {{ item.options|join(' ') }}

--- a/templates/vhost.conf.j2
+++ b/templates/vhost.conf.j2
@@ -12,6 +12,11 @@
 
 <VirtualHost *:{{ httpd_port }}>
    ServerName {{ item.servername }}
+
+   {% if item.serveralias is defined %}
+   ServerAlias {{ item.serveralias | join(' ') }}
+   {% endif %}
+
 {% if item.options is defined %}
    Options {{ item.options|join(' ') }}
 {% endif %}


### PR DESCRIPTION
---
name: Pull request
about: Server alias support for vhost

---

**Describe the change**
Hello this is just little change that adds support for ServerAlias entry in config. So if you'd like it you can merge it. ;-)

**Testing**
I tested it on my local ansible setup.
