### PR TITLE
include mod_proxy when remote vhost is defined

### DIFF
--- a/templates/vhost.conf.j2
+++ b/templates/vhost.conf.j2
@@ -1,6 +1,6 @@
 {{ ansible_managed | comment }}
 
-{% if item.backend_url is defined %}
+{% if ( item.backend_url is defined ) or ( item.remote is defined ) %}
 <IfModule !proxy_module>
    LoadModule proxy_module {{ httpd_modules_path }}/mod_proxy.so
 </IfModule>


### PR DESCRIPTION
---
name: Pull request
about: Describe the proposed change

solves #14

---

**Describe the change**
A clear and concise description of what the pull request is.

Jinja now automatically checks for item.remote alongside backside.url to include mod_proxy
**Testing**
In case a feature was added, how were tests performed?

Local testing with Ubuntu 20.04 LTS machine