### PR TITLE
added required ip addresses for directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ This example is taken from [`molecule/default/converge.yml`](https://github.com/
       #           - FollowSymLinks
       #         allow_override: All
       #         require: all granted
+      #   - name: vhost-with-ips
+      #     servername: secure.example.com
+      #        require: all denied
+      #        ip:
+      #         - 8.8.8.8
+      #         - 9.9.9.9
 
       httpd_directories:
         - name: my_directory

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ This example is taken from [`molecule/default/converge.yml`](https://github.com/
       #   - name: vhost-with-ips
       #     servername: secure.example.com
       #        require: all denied
-      #        ip:
+      #        ips:
       #         - 8.8.8.8
       #         - 9.9.9.9
 

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -243,3 +243,12 @@
       - default_vhost_conf is defined
       - default_vhost_conf is string
     quiet: true
+
+- name: assert | Test for illegal combination of Require and ips
+  ansible.builtin.assert:
+    that:
+      - (directory.require is defined and directory.ip is not defined) or (directory.require is not defined and directory.ip is defined) or (directory.require = 'all denied' and directory.ip is defined) 
+    fail_msg: >-
+      When using an 'ip' list, the 'require' key must either be 'all denied'
+      or not defined at all. It cannot be '{{ directory.require }}'.
+    quiet: true

--- a/templates/vhost.conf.j2
+++ b/templates/vhost.conf.j2
@@ -18,27 +18,27 @@
 
 <VirtualHost *:{{ item.port | default(httpd_port) }}>
    ServerName {{ item.servername }}
-
 {% if item.serveralias is defined %}
    ServerAlias {{ item.serveralias | join(' ') }}
 {% endif %}
-
 {% if item.redirect_to_https is defined and item.redirect_to_https %}
+
    RewriteEngine On
    RewriteCond %{HTTPS} off
    RewriteRule ^(.*)$ https://%{SERVER_NAME}:{{ item.ssl_port | default(httpd_ssl_port) }}%{REQUEST_URI} [L,R=301]
 {% else %}
-
 {% if item.ssl_certificate_file is defined %}
+
    SSLEngine on
    SSLCertificateFile "{{ item.ssl_certificate_file }}"
    SSLCertificateKeyFile "{{ item.ssl_certificate_key_file }}"
 {% endif %}
-
 {% if item.options is defined %}
+
    Options {{ item.options|join(' ') }}
 {% endif %}
 {% if item.documentroot is defined %}
+
    DocumentRoot "{{ item.documentroot }}"
 {% endif %}
 {% if item.backend_url is defined %}
@@ -70,19 +70,33 @@ ProxyPass / {{ item.backend_url }}
 {% if item.locations is defined %}
 {% for location in item.locations %}
    <Location {{ location.location }}>
-     ProxyPass {{ location.backend_url }}
-     ProxyPassReverse {{ location.backend_url }}
+      ProxyPass {{ location.backend_url }}
+      ProxyPassReverse {{ location.backend_url }}
    </Location>
 {% endfor %}
 {% endif %}
 {% if item.directories is defined %}
 {% for directory in item.directories %}
-   <Directory "{{ directory.path }}">
-     Options {% for option in directory.options %}{{ option }}{% if not loop.last %} {% endif %}{% endfor %}
 
-     AllowOverride {{ directory.allow_override }}
-     Require {{ directory.require }}
+   <Directory "{{ directory.path }}">
+
+      Options {% for option in directory.options %}{{ option }}{% if not loop.last %} {% endif %}{% endfor %}
+        
+      AllowOverride {{ directory.allow_override }}
+{% if directory.require is defined and not directory.ips is defined %}
+        
+      Require {{ directory.require }}
+{% endif %}
+{% if directory.ips is defined and directory.ips is iterable and directory.ips is not string %}
+        
+      Require all denied
+{% for ip_addr in directory.ips %}
+      Require ip {{ ip_addr }}
+{% endfor %}
+{% endif %}
+
    </Directory>
+
 {% endfor %}
 {% endif %}
 {% if item.error_log is defined %}
@@ -91,4 +105,5 @@ ProxyPass / {{ item.backend_url }}
 {% if item.custom_log is defined %}
    CustomLog {{ item.custom_log }} combined
 {% endif %}
+
 </VirtualHost>


### PR DESCRIPTION
Added required ip addresses  for directory and fixed some indenting and multiple adjacent empty lines.
---

Added the functionality to define required ip adresses that have access to a  configured directory

Also updated the template to reduce the number of adjacent empty lines.

Example:
```
      #   - name: vhost-with-ips
      #     servername: secure.example.com
      #        require: all denied
      #        ips:
      #         - 8.8.8.8
      #         - 9.9.9.9
```


